### PR TITLE
Add Github repository variable resource 

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ No modules.
 | Name | Type |
 |------|------|
 | [github_actions_secret.default](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/actions_secret) | resource |
+| [github_actions_variable.example_variable](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/actions_variable) | resource |
 | [github_branch_protection.default](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/branch_protection) | resource |
 | [github_repository.default](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/repository) | resource |
 | [github_repository_tag_protection.default](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/repository_tag_protection) | resource |
@@ -63,10 +64,10 @@ No modules.
 | <a name="input_name"></a> [name](#input\_name) | Repository name | `string` | n/a | yes |
 | <a name="input_required_checks"></a> [required\_checks](#input\_required\_checks) | List of required checks | `list(string)` | `[]` | no |
 | <a name="input_secrets"></a> [secrets](#input\_secrets) | key:value map for GitHub actions secrets | `map(any)` | `{}` | no |
-| <a name="input_variables"></a> [variables](#input\_variables) | key:value map for GitHub repository variables | `map(any)` | `{}` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Common tags to be used by all resources | `map(string)` | n/a | yes |
 | <a name="input_topics"></a> [topics](#input\_topics) | n/a | `list(string)` | `[]` | no |
 | <a name="input_type"></a> [type](#input\_type) | Type of repository: `core`, `module`, `template`. Defaults to `core` | `string` | `"core"` | no |
+| <a name="input_variables"></a> [variables](#input\_variables) | key:value map for repository variables | `map(any)` | `{}` | no |
 | <a name="input_visibility"></a> [visibility](#input\_visibility) | Visibility type: `public`, `internal`, `private` | `string` | `"public"` | no |
 
 ## Outputs

--- a/README.md
+++ b/README.md
@@ -63,7 +63,6 @@ No modules.
 | <a name="input_name"></a> [name](#input\_name) | Repository name | `string` | n/a | yes |
 | <a name="input_required_checks"></a> [required\_checks](#input\_required\_checks) | List of required checks | `list(string)` | `[]` | no |
 | <a name="input_secrets"></a> [secrets](#input\_secrets) | key:value map for GitHub actions secrets | `map(any)` | `{}` | no |
-| <a name="input_variables"></a> [variables](#input\_variables) | key:value map for GitHub repository variables | `map(any)` | `{}` | no |
 | <a name="input_topics"></a> [topics](#input\_topics) | n/a | `list(string)` | `[]` | no |
 | <a name="input_type"></a> [type](#input\_type) | Type of repository: `core`, `module`, `template`. Defaults to `core` | `string` | `"core"` | no |
 | <a name="input_variables"></a> [variables](#input\_variables) | key:value map for repository variables | `map(any)` | `{}` | no |

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ No modules.
 | <a name="input_name"></a> [name](#input\_name) | Repository name | `string` | n/a | yes |
 | <a name="input_required_checks"></a> [required\_checks](#input\_required\_checks) | List of required checks | `list(string)` | `[]` | no |
 | <a name="input_secrets"></a> [secrets](#input\_secrets) | key:value map for GitHub actions secrets | `map(any)` | `{}` | no |
+| <a name="input_variables"></a> [variables](#input\_variables) | key:value map for GitHub repository variables | `map(any)` | `{}` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Common tags to be used by all resources | `map(string)` | n/a | yes |
 | <a name="input_topics"></a> [topics](#input\_topics) | n/a | `list(string)` | `[]` | no |
 | <a name="input_type"></a> [type](#input\_type) | Type of repository: `core`, `module`, `template`. Defaults to `core` | `string` | `"core"` | no |

--- a/README.md
+++ b/README.md
@@ -8,9 +8,8 @@
 
 module "template" {
 
-  source = "github.com/ministryofjustice/operations-engineering-terraform-github-repositories"
+  source = "github.com/ministryofjustice/operations-engineering-terraform-github-repository?ref=X.X.X"
 
-  tags             = local.tags
   application_name = local.application_name
 
 }
@@ -64,7 +63,6 @@ No modules.
 | <a name="input_required_checks"></a> [required\_checks](#input\_required\_checks) | List of required checks | `list(string)` | `[]` | no |
 | <a name="input_secrets"></a> [secrets](#input\_secrets) | key:value map for GitHub actions secrets | `map(any)` | `{}` | no |
 | <a name="input_variables"></a> [variables](#input\_variables) | key:value map for GitHub repository variables | `map(any)` | `{}` | no |
-| <a name="input_tags"></a> [tags](#input\_tags) | Common tags to be used by all resources | `map(string)` | n/a | yes |
 | <a name="input_topics"></a> [topics](#input\_topics) | n/a | `list(string)` | `[]` | no |
 | <a name="input_type"></a> [type](#input\_type) | Type of repository: `core`, `module`, `template`. Defaults to `core` | `string` | `"core"` | no |
 | <a name="input_visibility"></a> [visibility](#input\_visibility) | Visibility type: `public`, `internal`, `private` | `string` | `"public"` | no |

--- a/main.tf
+++ b/main.tf
@@ -87,3 +87,10 @@ resource "github_actions_secret" "default" {
   secret_name     = each.key
   plaintext_value = each.value
 }
+
+resource "github_actions_variable" "example_variable" {
+  for_each      = var.variables
+  repository    = github_repository.default.id
+  variable_name = each.key
+  value         = each.value
+}

--- a/test/unit-test/locals.tf
+++ b/test/unit-test/locals.tf
@@ -20,14 +20,6 @@ locals {
   is-test          = substr(terraform.workspace, length(local.application_name), length(terraform.workspace)) == "-test"
   is-development   = substr(terraform.workspace, length(local.application_name), length(terraform.workspace)) == "-development"
 
-  # Merge tags from the environment json file with additional ones
-  tags = merge(
-    jsondecode(data.http.environments_file.response_body).tags,
-    { "is-production" = local.is-production },
-    { "environment-name" = terraform.workspace },
-    { "source-code" = "https://github.com/ministryofjustice/modernisation-platform" }
-  )
-
   environment = trimprefix(terraform.workspace, "${var.networking[0].application}-")
   vpc_name    = var.networking[0].business-unit
   subnet_set  = var.networking[0].set

--- a/test/unit-test/main.tf
+++ b/test/unit-test/main.tf
@@ -1,5 +1,4 @@
 
 module "module_test" {
   source = "../../"
-  tags   = local.tags
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,7 +1,3 @@
-variable "tags" {
-  type        = map(string)
-  description = "Common tags to be used by all resources"
-}
 variable "application_name" {
   type        = string
   description = "Name of application"

--- a/variables.tf
+++ b/variables.tf
@@ -29,6 +29,12 @@ variable "secrets" {
   default     = {}
 }
 
+variable "variables" {
+  type        = map(any)
+  description = "key:value map for repository variables"
+  default     = {}
+}
+
 variable "topics" {
   type    = list(string)
   default = []


### PR DESCRIPTION
Add Github repository variable resource to repository variables can be defined in IaC. 

Also removes tags TF variable, as github provedr doesn't support tags as a method of tagging all resources and they weren't being used.