### PR TITLE
Moved block for github repo and branch protection

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,16 @@
 # Repository basics
 #tfsec:ignore:github-repositories-private
+
+moved {
+  from = github_repository.this
+  to   = github_repository.default
+}
+
+moved {
+  from = github_branch_protection.this
+  to   = github_branch_protection.default
+}
+
 resource "github_repository" "default" {
   name                   = var.name
   description            = join(" • ", [var.description, "This repository is defined and managed in Terraform"])


### PR DESCRIPTION
- Moved block to account for different naming of resources used by the module and by other teams in P&A, allowing teams to transition to use this module. 