### PR TITLE
Update code analysis action version and replace `tfsec` with `trivy`

### DIFF
--- a/.github/workflows/terraform-static-analysis.yml
+++ b/.github/workflows/terraform-static-analysis.yml
@@ -25,12 +25,12 @@ jobs:
       with:
         fetch-depth: 0
     - name: Run Analysis
-      uses: ministryofjustice/github-actions/terraform-static-analysis@7c689fe2de15e1692f5cceceb132919ab854081c # v14
+      uses: ministryofjustice/github-actions/terraform-static-analysis@7855159a5c3a9bcd658207c894cc4ed22bd35a22 # v15.3.0
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         scan_type: single
-        tfsec_exclude: aws-cloudwatch-log-group-customer-key, aws-iam-no-policy-wildcards, aws-vpc-no-public-egress-sgr, aws-iam-block-kms-policy-wildcard, aws-vpc-add-description-to-security-group
+        tfsec_trivy: trivy
         checkov_exclude: CKV_GIT_1
 
   terraform-static-analysis-full-scan:
@@ -45,10 +45,10 @@ jobs:
       with:
         fetch-depth: 0
     - name: Run Analysis
-      uses: ministryofjustice/github-actions/terraform-static-analysis@7c689fe2de15e1692f5cceceb132919ab854081c # v14
+      uses: ministryofjustice/github-actions/terraform-static-analysis@7855159a5c3a9bcd658207c894cc4ed22bd35a22 # v15.3.0
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         scan_type: full
-        tfsec_exclude: aws-cloudwatch-log-group-customer-key, aws-iam-no-policy-wildcards, aws-vpc-no-public-egress-sgr, aws-iam-block-kms-policy-wildcard, aws-vpc-add-description-to-security-group
+        tfsec_trivy: trivy
         checkov_exclude: CKV_GIT_1

--- a/.github/workflows/terraform-static-analysis.yml
+++ b/.github/workflows/terraform-static-analysis.yml
@@ -30,6 +30,7 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         scan_type: single
+        tflint_exclude: terraform_unused_declarations
         tfsec_trivy: trivy
         checkov_exclude: CKV_GIT_1
 
@@ -50,5 +51,6 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         scan_type: full
+        tflint_exclude: terraform_unused_declarations
         tfsec_trivy: trivy
         checkov_exclude: CKV_GIT_1


### PR DESCRIPTION
As [tfsec is joining the Trivy family](https://github.com/aquasecurity/tfsec/discussions/1994), this PR replaces the use of tfsec in this repository with Trivy.

It does so by updating the version of the [terraform-static-analysis](https://github.com/ministryofjustice/github-actions/tree/main/terraform-static-analysis) action and removing entrypoints that are no longer relevant.

A point of note is that inline ignores are not handled the same way in Trivy as in tfsec. If we want to replicate that functionality, we'd need to provision a `.trivyignore` file.

* https://aquasecurity.github.io/trivy/v0.48/docs/configuration/filtering/