### PR TITLE
corrected path for terraform dependabot scan

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,7 @@
 version: 2
 updates:
   - package-ecosystem: "terraform"
-    directory: "/terraform"
+    directory: "/"
     schedule:
       interval: "daily"
   - package-ecosystem: "github-actions"


### PR DESCRIPTION
Terraform code is held in the repository root, not a `terraform/` directory, so this PR will allow dependabot to correctly scan for module updates.