### PR TITLE
Remove MP refs from CONTRIB, and application_name refs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,15 +1,15 @@
 # Contribution guidelines
 
-When contributing to this repository, please first discuss the change you wish to make via issue, slack, or any other method with the owners of this repository before making a change.
+When contributing to this repository, please first discuss the change you wish to make via issue, slack, or any other method with the owners of this repository.
 
-Our primary slack channel for contributors who wish to get in touch is #ask-modernisation-platform.
+Our primary slack channel for contributors who wish to get in touch is #ask-operations-engineering.
 
 ## Contributing
 
 If you’ve got an idea or suggestion you can:
 
-- [Contact the Modernisation Platform team](https://mojdt.slack.com/archives/C01A7QK5VM1)
-- [Create a GitHub issue](https://github.com/ministryofjustice/modernisation-platform/issues)
+- [Contact the Operations Engineering team](https://moj.enterprise.slack.com/archives/C01BUKJSZD4)
+- [Create a GitHub issue in our main repository](https://github.com/ministryofjustice/operations-engineering/issues)
 
 ## Raising bugs
 
@@ -21,45 +21,36 @@ When describing the bug, it's useful to follow the format:
 - What you expected to happen
 - What happened
 
-We have a [standard template](https://github.com/ministryofjustice/modernisation-platform/issues/new?assignees=&labels=bug&projects=&template=bug-template.md) for raising bugs.
-
 ## Suggesting features
 
-Please [raise feature requests as issues](https://github.com/ministryofjustice/modernisation-platform/issues/new?assignees=&labels=&projects=&template=story-template.md) before contributing any code.
-
-Raising an issue ensures they are openly discussed and before spending any time on them.
+Please raise feature requests as issues using our [feature request template](https://github.com/ministryofjustice/operations-engineering/issues/new?assignees=&labels=github%2Cfeature+request%2Cthird+party&projects=&template=github-feature-requests.md&title=). This ensures requests are openly discussed before any code is contributed.
 
 ## Security vulnerabilities
 
-Please contact us through [Slack](https://mojdt.slack.com/archives/C01A7QK5VM1) to discuss the vulnerability first, before [raising an issue](https://github.com/ministryofjustice/modernisation-platform/security/advisories/new).
+Please contact us via [Slack](https://mojdt.slack.com/archives/C01BUKJSZD4) to discuss the vulnerability first. Then raise an issue using our [report a security vulnerabilty template](https://github.com/ministryofjustice/operations-engineering/security/advisories/new).
 
 ## Contributing code
 
 ### Terraform Versions
 
-We use Hashicorp [Terraform](https://www.terraform.io/) to deliver Infrastructure-as-Code.
+We use Hashicorp [Terraform](https://www.terraform.io/) to deliver infrastructure as code.
 
-We stay up-to-date with the latest versions of Terraform, but with Terraform Providers the Modernisation Platform Team control the version in use.
+We stay up to date with the latest version of Terraform, but control the version of the Terraform Providers in use.
 
 ### Tests
 
-Our versioned Terraform modules have unit tests; these are written using [Terratest](https://pkg.go.dev/github.com/gruntwork-io/terratest#section-readme) and Google Go.
+Our versioned Terraform modules have unit tests; these are written using [Terratest](https://pkg.go.dev/github.com/gruntwork-io/terratest#section-readme) and Go.
 
-Your branch should ensure that changes you have made are reflected in the tests, and that these unit tests pass before raising a Pull Request.
+Your branch should ensure that changes you have made are reflected in the tests, and that these unit tests pass before raising a pull request.
 
-A GitHub Action will automatically run tests against your Pull Request once you have raised it.
+A GitHub Action will automatically run tests against your pull request once you have raised it.
 
 ### Versioning
 
-Where appropriate, versioning is based on your commit messages by using [Semantic Versioning](https://semver.org/).
+Where appropriate, versioning is based on your commit message using [Semantic Versioning](https://semver.org/).
 
-Our [Modernisation Platform](https://github.com/ministryofjustice/modernisation-platform/) and [Modernisation Platform Environments](https://github.com/ministryofjustice/modernisation-platform-environments/) repositories are deployed with CI/CD from the _main_ branch, and thus are not versioned.
-
-Terraform modules which are used by the [Modernisation Platform](https://github.com/ministryofjustice/modernisation-platform/) and [Modernisation Platform Environments](https://github.com/ministryofjustice/modernisation-platform-environments/) repositories
-are versioned using GitHub Tags and Releases following Semantic Versioning.
-
-When you come to raise a pull request, please explain the context for your pull request so that your changes are easier to understand.
+When raising a pull request please provide context so that your changes are easier to understand.
 
 ### Release
 
-Releases are actioned by the Modernisation Platform team.
+Releases are actioned by the Operations Engineering team.

--- a/README.md
+++ b/README.md
@@ -59,7 +59,6 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_application_name"></a> [application\_name](#input\_application\_name) | Name of application | `string` | n/a | yes |
 | <a name="input_description"></a> [description](#input\_description) | Repository description | `string` | n/a | yes |
 | <a name="input_has_discussions"></a> [has\_discussions](#input\_has\_discussions) | Enable repository discussions | `bool` | `false` | no |
 | <a name="input_homepage_url"></a> [homepage\_url](#input\_homepage\_url) | Repository homepage URL | `string` | `""` | no |

--- a/main.tf
+++ b/main.tf
@@ -30,7 +30,7 @@ resource "github_repository" "default" {
   archived               = false
   archive_on_destroy     = true
   vulnerability_alerts   = true
-  topics                 = concat(var.topics, ["operations-engineering"])
+  topics                 = var.topics
 
   security_and_analysis {
     dynamic "advanced_security" {

--- a/variables.tf
+++ b/variables.tf
@@ -1,8 +1,3 @@
-variable "application_name" {
-  type        = string
-  description = "Name of application"
-}
-
 variable "name" {
   type        = string
   description = "Repository name"


### PR DESCRIPTION
## 👀 Purpose

- To tidy up some left overs from building this code from a Modernisation Platform (MP) example.

## ♻️ What's changed

- ♻️ Updated CONTRIB to replace references to MP with Operations Engineering
- 🔥 Removed redundant `application_name` variable from `variables.tf`
- 🔥 Removed `operations-engineering` as a default topic from the module

## 📝 Notes

-