### PR TITLE
Add team_access optional input

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ No modules.
 | <a name="input_type"></a> [type](#input\_type) | Type of repository: `core`, `module`, `template`. Defaults to `core` | `string` | `"core"` | no |
 | <a name="input_variables"></a> [variables](#input\_variables) | key:value map for repository variables | `map(any)` | `{}` | no |
 | <a name="input_visibility"></a> [visibility](#input\_visibility) | Visibility type: `public`, `internal`, `private` | `string` | `"public"` | no |
+| <a name="input_team_access"></a> [team_access](#input\_team__access) | Team access types for created repository: `admin`, `maintain`, `push` | `list(string)` | `[]` | no |
 
 ## Outputs
 

--- a/README.md
+++ b/README.md
@@ -53,6 +53,9 @@ No modules.
 | [github_branch_protection.default](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/branch_protection) | resource |
 | [github_repository.default](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/repository) | resource |
 | [github_repository_tag_protection.default](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/repository_tag_protection) | resource |
+| [github_team_repository.admin](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/team_repository) | resource |
+| [github_team_repository.maintain](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/team_repository) | resource |
+| [github_team_repository.push](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/team_repository) | resource |
 | [github_actions_public_key.default](https://registry.terraform.io/providers/integrations/github/latest/docs/data-sources/actions_public_key) | data source |
 
 ## Inputs
@@ -65,11 +68,11 @@ No modules.
 | <a name="input_name"></a> [name](#input\_name) | Repository name | `string` | n/a | yes |
 | <a name="input_required_checks"></a> [required\_checks](#input\_required\_checks) | List of required checks | `list(string)` | `[]` | no |
 | <a name="input_secrets"></a> [secrets](#input\_secrets) | key:value map for GitHub actions secrets | `map(any)` | `{}` | no |
+| <a name="input_team_access"></a> [team\_access](#input\_team\_access) | Team access types for created repository | <pre>object({<br>    admin    = optional(list(string))<br>    maintain = optional(list(string))<br>    push     = optional(list(string))<br>  })</pre> | <pre>{<br>  "admin": [],<br>  "maintain": [],<br>  "push": []<br>}</pre> | no |
 | <a name="input_topics"></a> [topics](#input\_topics) | n/a | `list(string)` | `[]` | no |
 | <a name="input_type"></a> [type](#input\_type) | Type of repository: `core`, `module`, `template`. Defaults to `core` | `string` | `"core"` | no |
 | <a name="input_variables"></a> [variables](#input\_variables) | key:value map for repository variables | `map(any)` | `{}` | no |
 | <a name="input_visibility"></a> [visibility](#input\_visibility) | Visibility type: `public`, `internal`, `private` | `string` | `"public"` | no |
-| <a name="input_team_access"></a> [team_access](#input\_team__access) | Team access types for created repository: `admin`, `maintain`, `push` | `list(string)` | `[]` | no |
 
 ## Outputs
 

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ No modules.
 | [github_repository_tag_protection.default](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/repository_tag_protection) | resource |
 | [github_team_repository.admin](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/team_repository) | resource |
 | [github_team_repository.maintain](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/team_repository) | resource |
+| [github_team_repository.pull](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/team_repository) | resource |
 | [github_team_repository.push](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/team_repository) | resource |
 | [github_actions_public_key.default](https://registry.terraform.io/providers/integrations/github/latest/docs/data-sources/actions_public_key) | data source |
 
@@ -68,7 +69,7 @@ No modules.
 | <a name="input_name"></a> [name](#input\_name) | Repository name | `string` | n/a | yes |
 | <a name="input_required_checks"></a> [required\_checks](#input\_required\_checks) | List of required checks | `list(string)` | `[]` | no |
 | <a name="input_secrets"></a> [secrets](#input\_secrets) | key:value map for GitHub actions secrets | `map(any)` | `{}` | no |
-| <a name="input_team_access"></a> [team\_access](#input\_team\_access) | Team access types for created repository | <pre>object({<br>    admin    = optional(list(string))<br>    maintain = optional(list(string))<br>    push     = optional(list(string))<br>  })</pre> | <pre>{<br>  "admin": [],<br>  "maintain": [],<br>  "push": []<br>}</pre> | no |
+| <a name="input_team_access"></a> [team\_access](#input\_team\_access) | Team access types for created repository | <pre>object({<br>    admin    = optional(list(string))<br>    maintain = optional(list(string))<br>    push     = optional(list(string))<br>    pull     = optional(list(string))<br>  })</pre> | <pre>{<br>  "admin": [],<br>  "maintain": [],<br>  "pull": [],<br>  "push": []<br>}</pre> | no |
 | <a name="input_topics"></a> [topics](#input\_topics) | n/a | `list(string)` | `[]` | no |
 | <a name="input_type"></a> [type](#input\_type) | Type of repository: `core`, `module`, `template`. Defaults to `core` | `string` | `"core"` | no |
 | <a name="input_variables"></a> [variables](#input\_variables) | key:value map for repository variables | `map(any)` | `{}` | no |
@@ -76,7 +77,5 @@ No modules.
 
 ## Outputs
 
-| Name | Description |
-|------|-------------|
-| <a name="output_repository_name"></a> [repository\_name](#output\_repository\_name) | Name of the created repository |
+No outputs.
 <!-- END_TF_DOCS -->

--- a/main.tf
+++ b/main.tf
@@ -129,3 +129,11 @@ resource "github_team_repository" "push" {
   repository = github_repository.default.name
   permission = "push"
 }
+
+resource "github_team_repository" "pull" {
+  for_each = var.team_access != null && var.team_access.pull != null ? { for team in var.team_access.pull : team => team } : {}
+
+  team_id    = each.value
+  repository = github_repository.default.name
+  permission = "pull"
+}

--- a/main.tf
+++ b/main.tf
@@ -110,7 +110,7 @@ resource "github_team_repository" "admin" {
   for_each = var.team_access != null && var.team_access.admin != null ? { for team in var.team_access.admin : team => team } : {}
 
   team_id    = each.value
-  repository = github_repository.this.name
+  repository = github_repository.default.name
   permission = "admin"
 }
 
@@ -118,7 +118,7 @@ resource "github_team_repository" "maintain" {
   for_each = var.team_access != null && var.team_access.maintain != null ? { for team in var.team_access.maintain : team => team } : {}
 
   team_id    = each.value
-  repository = github_repository.this.name
+  repository = github_repository.default.name
   permission = "maintain"
 }
 
@@ -126,6 +126,6 @@ resource "github_team_repository" "push" {
   for_each = var.team_access != null && var.team_access.push != null ? { for team in var.team_access.push : team => team } : {}
 
   team_id    = each.value
-  repository = github_repository.this.name
+  repository = github_repository.default.name
   permission = "push"
 }

--- a/main.tf
+++ b/main.tf
@@ -105,3 +105,27 @@ resource "github_actions_variable" "default" {
   variable_name = each.key
   value         = each.value
 }
+
+resource "github_team_repository" "admin" {
+  for_each = var.team_access != null && var.team_access.admin != null ? { for team in var.team_access.admin : team => team } : {}
+
+  team_id    = each.value
+  repository = github_repository.this.name
+  permission = "admin"
+}
+
+resource "github_team_repository" "maintain" {
+  for_each = var.team_access != null && var.team_access.maintain != null ? { for team in var.team_access.maintain : team => team } : {}
+
+  team_id    = each.value
+  repository = github_repository.this.name
+  permission = "maintain"
+}
+
+resource "github_team_repository" "push" {
+  for_each = var.team_access != null && var.team_access.push != null ? { for team in var.team_access.push : team => team } : {}
+
+  team_id    = each.value
+  repository = github_repository.this.name
+  permission = "push"
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,4 +1,4 @@
 output "repository_name" {
   description = "Name of the created repository"
-  value = github_repository.default.name
+  value       = github_repository.default.name
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,4 +1,0 @@
-output "repository_name" {
-  description = "Name of the created repository"
-  value       = github_repository.default.name
-}

--- a/variables.tf
+++ b/variables.tf
@@ -60,11 +60,13 @@ variable "team_access" {
     admin    = optional(list(string))
     maintain = optional(list(string))
     push     = optional(list(string))
+    pull     = optional(list(string))
   })
   description = "Team access types for created repository"
   default = {
     admin    = []
     maintain = []
     push     = []
+    pull     = []
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -54,3 +54,17 @@ variable "has_discussions" {
   description = "Enable repository discussions"
   default     = false
 }
+
+variable "team_access" {
+  type = object({
+    admin    = optional(list(string))
+    maintain = optional(list(string))
+    push     = optional(list(string))
+  })
+  description = "Team access types for created repository"
+  default = {
+    admin    = []
+    maintain = []
+    push     = []
+  }
+}


### PR DESCRIPTION
## 👀 Purpose

- To enable adding team access to repo on creation via the module.

## ♻️ What's changed

- ✨ Added optional object input `team_access` with four permission levels (access types): `admin`, `maintain`, `push` (write), `pull` (read).
- Lists of teams can then be referenced when the module is used and for each a team<->repo association is created with the given permission.
- 🔥 Removed repo name output (deleted `output.tf`) as not required.

## 📝 Notes
