### PR TITLE
Remove this to default moved blocks

### DIFF
--- a/.github/workflows/code-scanning.yml
+++ b/.github/workflows/code-scanning.yml
@@ -24,7 +24,7 @@ jobs:
           token: '${{ secrets.GITHUB_TOKEN }}'
           fetch-depth: 0
       - name: Cache plugin dir
-        uses: actions/cache@e12d46a63a90f2fae62d114769bbf2a179198b5c # v3.3.3
+        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
         with:
           path: ~/.tflint.d/plugins
           key: '${{ matrix.os }}-tflint-${{ hashFiles(''.tflint.hcl'') }}'

--- a/.github/workflows/terraform-static-analysis.yml
+++ b/.github/workflows/terraform-static-analysis.yml
@@ -34,7 +34,7 @@ jobs:
       with:
         fetch-depth: 0
     - name: Run Analysis
-      uses: ministryofjustice/github-actions/terraform-static-analysis@7132cd6c0569bd63ae7d5672f89ccada1e902bea # v17.0.1
+      uses: ministryofjustice/github-actions/terraform-static-analysis@1b6396ceb7bf09e741789c4e7eb7b329d5113066 # v15.4.1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:

--- a/.github/workflows/terraform-static-analysis.yml
+++ b/.github/workflows/terraform-static-analysis.yml
@@ -34,7 +34,7 @@ jobs:
       with:
         fetch-depth: 0
     - name: Run Analysis
-      uses: ministryofjustice/github-actions/terraform-static-analysis@1b6396ceb7bf09e741789c4e7eb7b329d5113066 # v15.4.1
+      uses: ministryofjustice/github-actions/terraform-static-analysis@72fe7d2b80a33b5e3f23dffa31236bd45027450b # v18.1.1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:

--- a/.github/workflows/terraform-static-analysis.yml
+++ b/.github/workflows/terraform-static-analysis.yml
@@ -22,7 +22,7 @@ jobs:
     if: github.event_name != 'workflow_dispatch'
     steps:
     - name: Delete Old Comments
-      uses: maheshrayas/action-pr-comment-delete@v06d7254b4aeba4491a66a7e0f755b107f7373ccd # v3.0
+      uses: maheshrayas/action-pr-comment-delete@06d7254b4aeba4491a66a7e0f755b107f7373ccd # v3.0
       with:
         github_token: '${{ secrets.GITHUB_TOKEN }}'
         org: ministryofjustice

--- a/.github/workflows/terraform-static-analysis.yml
+++ b/.github/workflows/terraform-static-analysis.yml
@@ -34,7 +34,7 @@ jobs:
       with:
         fetch-depth: 0
     - name: Run Analysis
-      uses: ministryofjustice/github-actions/terraform-static-analysis@72fe7d2b80a33b5e3f23dffa31236bd45027450b # v18.1.1
+      uses: ministryofjustice/github-actions/terraform-static-analysis@8e1bfc920f829ce408a5ef84118fbc160e559066 # v18.1.2
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:

--- a/.github/workflows/terraform-static-analysis.yml
+++ b/.github/workflows/terraform-static-analysis.yml
@@ -42,3 +42,4 @@ jobs:
         tflint_exclude: terraform_unused_declarations
         tfsec_trivy: trivy
         checkov_exclude: CKV_GIT_1
+        trivy_ignore: .trivyignore.yaml

--- a/.github/workflows/terraform-static-analysis.yml
+++ b/.github/workflows/terraform-static-analysis.yml
@@ -22,7 +22,7 @@ jobs:
     if: github.event_name != 'workflow_dispatch'
     steps:
     - name: Delete Old Comments
-      uses: maheshrayas/action-pr-comment-delete@v3.0
+      uses: maheshrayas/action-pr-comment-delete@v06d7254b4aeba4491a66a7e0f755b107f7373ccd # v3.0
       with:
         github_token: '${{ secrets.GITHUB_TOKEN }}'
         org: ministryofjustice

--- a/.github/workflows/terraform-static-analysis.yml
+++ b/.github/workflows/terraform-static-analysis.yml
@@ -34,7 +34,7 @@ jobs:
       with:
         fetch-depth: 0
     - name: Run Analysis
-      uses: ministryofjustice/github-actions/terraform-static-analysis@7855159a5c3a9bcd658207c894cc4ed22bd35a22 # v15.3.0
+      uses: ministryofjustice/github-actions/terraform-static-analysis@7132cd6c0569bd63ae7d5672f89ccada1e902bea # v17.0.1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:

--- a/.github/workflows/terraform-unit-tests.yml
+++ b/.github/workflows/terraform-unit-tests.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4 
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
       - name: Set up Python
         uses: actions/setup-python@39cd14951b08e74b54015e9e001cdefcf80e669f # 5.1.1

--- a/.github/workflows/terraform-unit-tests.yml
+++ b/.github/workflows/terraform-unit-tests.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/checkout@v4 
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@39cd14951b08e74b54015e9e001cdefcf80e669f # 5.1.1
         with:
           python-version: '3.11'
 

--- a/.trivyignore.yaml
+++ b/.trivyignore.yaml
@@ -1,0 +1,2 @@
+misconfigurations:
+  - id: AVD-GIT-0001 # ignore public repo CRITICAL vulnerability 

--- a/main.tf
+++ b/main.tf
@@ -1,16 +1,6 @@
 # Repository basics
 #tfsec:ignore:github-repositories-private
 
-moved {
-  from = github_repository.this
-  to   = github_repository.default
-}
-
-moved {
-  from = github_branch_protection.this
-  to   = github_branch_protection.default
-}
-
 resource "github_repository" "default" {
   name                   = var.name
   description            = join(" • ", [var.description, "This repository is defined and managed in Terraform"])


### PR DESCRIPTION
## 👀 Purpose

- Remove the moved blocks set up to convert from APs use of `.this` to modules' use of `.default` as this interferes with ability to do other moves (such as rename a repo without destroying it)
- wrt https://github.com/ministryofjustice/operations-engineering/issues/4612
## ♻️ What's changed

- 🔥 Moved blocks deleted

## 📝 Notes
- Confirmed with AP no impact
